### PR TITLE
ENH: Add CI to build/test LaTeX document

### DIFF
--- a/.github/workflows/build-test-latex.yml
+++ b/.github/workflows/build-test-latex.yml
@@ -1,0 +1,22 @@
+name: Build LaTeX document
+
+on: [push,pull_request]
+
+jobs:
+  build_latex:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v2
+      - name: Set up LaTeX packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install texlive texlive-publishers texlive-science latexmk
+      - name: Compile LaTeX document
+        run: |
+          cd Document/LaTeX
+          make
+      - name: Check pdf files
+        run: |
+          set -e
+          file Document/LaTeX/ArticleExample.pdf | grep -q ' PDF '

--- a/README
+++ b/README
@@ -1,3 +1,6 @@
+[![Build LaTeX document](https://github.com/InsightSoftwareConsortium/InsightJournalTemplate/actions/workflows/build-test-latex.yml/badge.svg?branch=master)](https://github.com/InsightSoftwareConsortium/InsightJournalTemplate/actions/workflows/build-test-latex.yml)
+
+[](https://github.com/InsightSoftwareConsortium/ITKSphinxExamples/actions?query=workflow%3A%22Build%2C+test%2C+publish%22+branch%3Amaster)
 This repository contains a template for submitting
 Technical Reports to the Insight Journal:
 


### PR DESCRIPTION
Add GitHub Actions workflow to build/test LaTeX document.

Add status badge to `README`.